### PR TITLE
Fix optional playlist association for Song entity and endpoints

### DIFF
--- a/src/main/java/org/mfnm/musicapi/controllers/SongController.java
+++ b/src/main/java/org/mfnm/musicapi/controllers/SongController.java
@@ -1,20 +1,104 @@
 package org.mfnm.musicapi.controllers;
 
+import lombok.AllArgsConstructor;
 import org.mfnm.musicapi.domain.entity.Song;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.mfnm.musicapi.service.SongService;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.*;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 
 @RestController
+@Validated
 @RequestMapping("/song")
+@AllArgsConstructor
 public class SongController {
-/*
-    must be implemented
-*/
+
+    private final SongService songService;
+
+    @GetMapping("/{title}")
+    public ResponseEntity<List<Song>> getSong(@PathVariable String title) {
+        List<Song> songs = this.songService.findByTitle(title);
+        return ResponseEntity.ok().body(songs);
+    }
+
+    @GetMapping("/id/{id}")
+    public ResponseEntity<Song> getSongById(@PathVariable Long id) {
+        Song song = this.songService.findById(id);
+        return ResponseEntity.ok().body(song);
+    }
+
+    @GetMapping("/download/{id}")
+    public ResponseEntity<Resource> downloadSong(@PathVariable Long id) {
+        try {
+            Song song = this.songService.findById(id);
+            byte[] audioData = song.getAudioData();
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(audioData);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.valueOf("audio/mpeg"));
+            headers.setContentDispositionFormData("attachment", song.getTitle() + ".mp3");
+
+            InputStreamResource resource = new InputStreamResource(byteArrayInputStream);
+            return new ResponseEntity<>(resource, headers, HttpStatus.OK);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+    @PostMapping("/upload")
+    @Validated
+    public ResponseEntity<String> createSong(@RequestParam MultipartFile file,
+                                             @RequestParam String title,
+                                             @RequestParam String artist,
+                                             @RequestParam(required = false) String albumTitle,
+                                             @RequestParam(required = false) Long playlistId) {
+
+        try {
+            Song song = new Song();
+            song.setTitle(title);
+            song.setArtist(artist);
+            song.setAlbumTitle(albumTitle);
+            song.setAudioData(file.getBytes());
+
+            Song createdSong = this.songService.create(song);
+
+            URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
+                    .path("/{id}")
+                    .buildAndExpand(createdSong.getId())
+                    .toUri();
+
+            return ResponseEntity.created(uri).body("File uploaded succefully");
+
+        } catch (IOException e) {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("File upload failed.");
+        }
+    }
+
+    @PutMapping("/update/{id}")
+    @Validated
+    public ResponseEntity<Song> updateSong(@PathVariable Long id, @Validated @RequestBody Song song) {
+        if (!id.equals(song.getId())) {
+            throw new IllegalArgumentException("ID in path and request body do not match.");
+        }
+        Song updatedSong = this.songService.update(song);
+        return ResponseEntity.ok(updatedSong);
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Void> deleteSong(@PathVariable Long id) {
+        this.songService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }
 

--- a/src/main/java/org/mfnm/musicapi/domain/entity/Playlist.java
+++ b/src/main/java/org/mfnm/musicapi/domain/entity/Playlist.java
@@ -38,10 +38,10 @@ public class Playlist {
     @JoinColumn(name = "user_id", nullable = false, updatable = false)
     private User user;
 
-    @Column(name = "playlist_name", length = 100)
+    @Column(name = "playlist_title", length = 100)
     @NotNull
     @NotEmpty
-    private String name;
+    private String title;
 
     @OneToMany(mappedBy = "playlist")
     private List<Song> songs = new ArrayList<>();

--- a/src/main/java/org/mfnm/musicapi/domain/entity/Song.java
+++ b/src/main/java/org/mfnm/musicapi/domain/entity/Song.java
@@ -1,8 +1,8 @@
 package org.mfnm.musicapi.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,23 +24,22 @@ public class Song {
     @Column(name = "id", unique = true)
     private Long id;
 
-    @Column(name = "songname", length = 100, nullable = false)
+    @Column(name = "songtitle", length = 100, nullable = false)
     @NotEmpty
-    private String name;
+    private String title;
 
     @Column(name = "artistname", length = 100, nullable = false)
     @NotEmpty
     private String artist;
 
-    @Column(name = "albumname", length = 100, nullable = true)
-    private String album;
+    @Column(name = "albumtitle", length = 100, nullable = true)
+    private String albumTitle;
 
-    /*
-     @Column(name = "audio_file_path", length = 255, nullable = true)
-     private Byte[] audioData;
-    */
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Column(name = "audio_data", columnDefinition = "LONGBLOB", nullable = true)
+    private byte[] audioData;
 
     @ManyToOne
-    @JoinColumn(name = "playlist_id", nullable = false, updatable = true)
+    @JoinColumn(name = "playlist_id", nullable = true, updatable = true)
     private Playlist playlist;
 }

--- a/src/main/java/org/mfnm/musicapi/repository/SongRepository.java
+++ b/src/main/java/org/mfnm/musicapi/repository/SongRepository.java
@@ -2,9 +2,18 @@ package org.mfnm.musicapi.repository;
 
 import org.mfnm.musicapi.domain.entity.Song;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface SongRepository extends JpaRepository<Song, Long> {
-    
+    public List<Song> findByTitle(String title);
+
+    public List<Song> findByArtist(String artist);
+
+    @Query("SELECT s FROM Song s WHERE s.albumTitle = :albumTitle")
+    public List<Song> findByAlbum(@Param("albumTitle") String albumTitle);
 }

--- a/src/main/java/org/mfnm/musicapi/service/SongService.java
+++ b/src/main/java/org/mfnm/musicapi/service/SongService.java
@@ -1,15 +1,57 @@
 package org.mfnm.musicapi.service;
 
 import lombok.AllArgsConstructor;
+import org.mfnm.musicapi.domain.entity.Song;
 import org.mfnm.musicapi.repository.SongRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @AllArgsConstructor
 public class SongService {
 
     private final SongRepository songRepository;
-    /*
-        must be implemented
-    */
+
+    public Song findById(Long id) {
+        Optional<Song> song = songRepository.findById(id);
+        return song.orElseThrow(() -> new RuntimeException(
+                "Song not found! Id: " + id
+        ));
+    }
+
+    public List<Song> findByTitle(String title) {
+        return songRepository.findByTitle(title);
+    }
+
+    public List<Song> findByArtist(String artist) {
+        return songRepository.findByArtist(artist);
+    }
+
+    public List<Song> findByAlbum(String album) {
+        return songRepository.findByAlbum(album);
+    }
+
+    @Transactional
+    public Song create(Song song) {
+        song.setId(null);
+        return songRepository.save(song);
+    }
+
+    @Transactional
+    public Song update(Song song) {
+        if (!songRepository.existsById(song.getId())) {
+            throw new RuntimeException("Song not found! Id: " + song.getId());
+        }
+        return songRepository.save(song);
+    }
+
+    public void delete(Long id) {
+        if (!songRepository.existsById(id)) {
+            throw new RuntimeException("Song not found! Id: " + id);
+        }
+        songRepository.deleteById(id);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,8 @@ spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://localhost:3306/music_db?createDatabaseIfNotExist=true
 spring.datasource.username=root
 spring.datasource.password=admin
+spring.jpa.properties.hibernate.type.wrapper_array_handling=ALLOW
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.show-sql=true
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
- Updated Song entity to make playlist association optional.
- Modified POST /upload endpoint to handle optional playlistId.
- Added support for associating or disassociating playlists in the PUT /update endpoint.
- Adjusted column definition for audio_data to LONGBLOB for large file storage.