### PR TITLE
Merge develop into main: Add Swagger UI for API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # MusicAPI
+
+## API Documentation
+
+This project uses Swagger UI to provide interactive API documentation.
+
+### Accessing the Documentation
+
+To view the API documentation, start the application and navigate to the following URL in your browser:
+http://localhost:8080/swagger-ui.html
+

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>


### PR DESCRIPTION
### Summary
This PR merges the `develop` branch into the `main` branch, incorporating the following key changes:
- Integration of Swagger UI for interactive API documentation.

### Changes
- **Dependencies:** Added Swagger UI dependency in `pom.xml`.
- **Configuration:** Created `SwaggerConfig` class to enable automatic endpoint documentation with Swagger UI.
- **Documentation:** Updated `README.md` with instructions on how to access the API documentation.

### How to Test
1. Checkout the `main` branch.
2. Merge the `develop` branch into `main`.
3. Start the application.
4. Open a web browser and navigate to `http://localhost:8080/swagger-ui.html` (adjust `localhost` and `8080` if necessary).
5. Verify that the Swagger UI loads and displays the available API endpoints correctly.

### Additional Notes
- The Swagger UI can be accessed at `/swagger-ui.html`.
- Make sure to update the host and port in the README if your application is configured differently.
